### PR TITLE
feat: Adding RequestOptions settings from environtment variables

### DIFF
--- a/credentials/McpClientSseApi.credentials.ts
+++ b/credentials/McpClientSseApi.credentials.ts
@@ -17,6 +17,14 @@ export class McpClientSseApi implements ICredentialType {
 			description: 'URL of the SSE endpoint for the MCP server',
 		},
 		{
+			displayName: 'SSE Connection Timeout',
+			name: 'sseTimeout',
+			type: 'number',
+			default: 60000,
+			required: false,
+			description: 'Timeout for the SSE connection in milliseconds. Default is 60 seconds.',
+		},
+		{
 			displayName: 'Messages Post Endpoint',
 			name: 'messagesPostEndpoint',
 			type: 'string',

--- a/nodes/McpClient/McpClient.node.ts
+++ b/nodes/McpClient/McpClient.node.ts
@@ -347,22 +347,6 @@ export class McpClient implements INodeType {
 				}
 			}
 
-			// Read resetTimeoutOnProgress from environment
-			if (process.env.MCP_RESET_TIMEOUT_ON_PROGRESS) {
-				requestOptions.resetTimeoutOnProgress = 
-					process.env.MCP_RESET_TIMEOUT_ON_PROGRESS.toLowerCase() === 'true';
-				this.logger.debug(`Setting resetTimeoutOnProgress: \${requestOptions.resetTimeoutOnProgress}`);
-			}
-
-			// Read maxTotalTimeout from environment
-			if (process.env.MCP_MAX_TOTAL_TIMEOUT_MS) {
-				const maxTimeoutMs = parseInt(process.env.MCP_MAX_TOTAL_TIMEOUT_MS, 10);
-				if (!isNaN(maxTimeoutMs) && maxTimeoutMs > 0) {
-					requestOptions.maxTotalTimeout = maxTimeoutMs;
-					this.logger.debug(`Using custom max total timeout: \${maxTimeoutMs}ms`);
-				}
-			}
-
 			switch (operation) {
 				case 'listResources': {
 					const resources = await client.listResources();

--- a/nodes/McpClient/McpClient.node.ts
+++ b/nodes/McpClient/McpClient.node.ts
@@ -195,6 +195,7 @@ export class McpClient implements INodeType {
 			// If connectionType parameter doesn't exist, keep default 'cmd'
 			this.logger.debug('ConnectionType parameter not found, using default "cmd" transport');
 		}
+		let timeout = 600000;
 
 		try {
 
@@ -207,6 +208,7 @@ export class McpClient implements INodeType {
 
 				const sseUrl = sseCredentials.sseUrl as string;
 				const messagesPostEndpoint = (sseCredentials.messagesPostEndpoint as string) || '';
+				timeout = sseCredentials.sseTimeout as number || 60000;
 
 				// Parse headers
 				let headers: Record<string, string> = {};
@@ -337,15 +339,7 @@ export class McpClient implements INodeType {
 
 			// Create a RequestOptions object from environment variables
 			const requestOptions: RequestOptions = {};
-
-			// Read timeout from environment
-			if (process.env.MCP_REQUEST_TIMEOUT_MS) {
-				const timeoutMs = parseInt(process.env.MCP_REQUEST_TIMEOUT_MS, 10);
-				if (!isNaN(timeoutMs) && timeoutMs > 0) {
-					requestOptions.timeout = timeoutMs;
-					this.logger.debug(`Using custom request timeout: \${timeoutMs}ms`);
-				}
-			}
+			requestOptions.timeout = timeout;
 
 			switch (operation) {
 				case 'listResources': {

--- a/nodes/McpClient/McpClient.node.ts
+++ b/nodes/McpClient/McpClient.node.ts
@@ -10,7 +10,7 @@ import { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import {RequestOptions} from '@modelcontextprotocol/sdk/shared/protocol.ts';
+import { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.ts';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';


### PR DESCRIPTION
## Description
This PR enables users to supply environment variables to update timeout settings for MCP clients

## Related Issue
[issue 29](https://github.com/nerding-io/n8n-nodes-mcp/issues/29)
Closes #

## Type of Change
- [X] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?
<!-- Describe the tests that you ran to verify your changes -->

## Checklist
- [X] My code follows the code style of this project
- [X] I have updated the documentation accordingly
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## Release Notes
<!-- Add brief notes for what should appear in release notes if applicable -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes --> 
