### PR TITLE
Added optional override for URL

### DIFF
--- a/nodes/McpClient/McpClient.node.ts
+++ b/nodes/McpClient/McpClient.node.ts
@@ -91,6 +91,19 @@ export class McpClient implements INodeType {
 				description: 'Choose the transport type to connect to MCP server',
 			},
 			{
+				displayName: 'Uri Override',
+				name: 'uriOverride',
+				type: 'string',
+				required: false,
+				displayOptions: {
+					show: {
+						connectionType: ['sse', 'http'],
+					},
+				},
+				default: '',
+				description: 'Override the URL from credentials with a custom URL',
+			},
+			{
 				displayName: 'Operation',
 				name: 'operation',
 				type: 'options',
@@ -220,7 +233,9 @@ export class McpClient implements INodeType {
 				// Dynamically import the HTTP client
 				const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
 
-				const httpStreamUrl = httpCredentials.httpStreamUrl as string;
+				// Get URI override or use credentials URL
+				const uriOverride = this.getNodeParameter('uriOverride', 0) as string;
+				const httpStreamUrl = uriOverride || (httpCredentials.httpStreamUrl as string);
 				const messagesPostEndpoint = (httpCredentials.messagesPostEndpoint as string) || '';
 				timeout = httpCredentials.httpTimeout as number || 60000;
 
@@ -258,7 +273,9 @@ export class McpClient implements INodeType {
 				// Dynamically import the SSE client to avoid TypeScript errors
 				const { SSEClientTransport } = await import('@modelcontextprotocol/sdk/client/sse.js');
 
-				const sseUrl = sseCredentials.sseUrl as string;
+				// Get URI override or use credentials URL
+				const uriOverride = this.getNodeParameter('uriOverride', 0) as string;
+				const sseUrl = uriOverride || (sseCredentials.sseUrl as string);
 				const messagesPostEndpoint = (sseCredentials.messagesPostEndpoint as string) || '';
 				timeout = sseCredentials.sseTimeout as number || 60000;
 


### PR DESCRIPTION
## Description
In my environment, I have multiple mcp server for various kubernetes clusters. They all take the same credentials, but the URL to connect with are different. The URL is determined from the user's AI prompt so I would like to be able to dynamically chose my MCP server. I have added an optional Override URL to the SSE & HTTP endpoints.



## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
I have tested this in my local environment.

## Checklist
- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Release Notes
<!-- Add brief notes for what should appear in release notes if applicable -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes --> 
