### PR TITLE
feat: headers override for MCP operations

### DIFF
--- a/nodes/McpClient/__tests__/utils.test.ts
+++ b/nodes/McpClient/__tests__/utils.test.ts
@@ -1,0 +1,137 @@
+import { parseHeaders, mergeHeaders } from '../utils';
+
+describe('MCP Client Utils', () => {
+	describe('parseHeaders', () => {
+		it('should parse newline-separated NAME=VALUE headers', () => {
+			const input = 'Authorization=Bearer token123\nContent-Type=application/json';
+			const result = parseHeaders(input);
+			expect(result).toEqual({
+				Authorization: 'Bearer token123',
+				'Content-Type': 'application/json',
+			});
+		});
+
+		it('should handle headers with equals signs in values', () => {
+			const input = 'Api-Key=abc=def=ghi';
+			const result = parseHeaders(input);
+			expect(result).toEqual({
+				'Api-Key': 'abc=def=ghi',
+			});
+		});
+
+		it('should ignore empty lines and malformed entries', () => {
+			const input = 'Valid-Header=value\n\n=NoKey\nNoEquals\nAnother-Header=value2';
+			const result = parseHeaders(input);
+			expect(result).toEqual({
+				'Valid-Header': 'value',
+				'Another-Header': 'value2',
+			});
+		});
+
+		it('should trim whitespace from keys and values', () => {
+			const input = '  Authorization  =  Bearer token  \n  Content-Type  =  application/json  ';
+			const result = parseHeaders(input);
+			expect(result).toEqual({
+				Authorization: 'Bearer token',
+				'Content-Type': 'application/json',
+			});
+		});
+
+		it('should handle empty string input', () => {
+			const result = parseHeaders('');
+			expect(result).toEqual({});
+		});
+
+		it('should handle multiple headers with various formats', () => {
+			const input =
+				'X-Api-Key=secret123\nAuthorization=Bearer xyz\nX-Custom-Header=value=with=equals';
+			const result = parseHeaders(input);
+			expect(result).toEqual({
+				'X-Api-Key': 'secret123',
+				Authorization: 'Bearer xyz',
+				'X-Custom-Header': 'value=with=equals',
+			});
+		});
+	});
+
+	describe('mergeHeaders', () => {
+		it('should merge credential and override headers', () => {
+			const credentialHeaders = {
+				'X-Api-Key': 'from-credentials',
+				'Content-Type': 'application/json',
+			};
+			const overrideHeaders = {
+				Authorization: 'Bearer override-token',
+			};
+			const result = mergeHeaders(credentialHeaders, overrideHeaders);
+			expect(result).toEqual({
+				'X-Api-Key': 'from-credentials',
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer override-token',
+			});
+		});
+
+		it('should allow override headers to take precedence over credential headers', () => {
+			const credentialHeaders = {
+				Authorization: 'Bearer credential-token',
+				'X-Custom': 'credential-value',
+			};
+			const overrideHeaders = {
+				Authorization: 'Bearer override-token',
+			};
+			const result = mergeHeaders(credentialHeaders, overrideHeaders);
+			expect(result).toEqual({
+				Authorization: 'Bearer override-token',
+				'X-Custom': 'credential-value',
+			});
+		});
+
+		it('should handle empty override headers', () => {
+			const credentialHeaders = {
+				Authorization: 'Bearer token',
+			};
+			const overrideHeaders = {};
+			const result = mergeHeaders(credentialHeaders, overrideHeaders);
+			expect(result).toEqual({
+				Authorization: 'Bearer token',
+			});
+		});
+
+		it('should handle empty credential headers', () => {
+			const credentialHeaders = {};
+			const overrideHeaders = {
+				Authorization: 'Bearer token',
+			};
+			const result = mergeHeaders(credentialHeaders, overrideHeaders);
+			expect(result).toEqual({
+				Authorization: 'Bearer token',
+			});
+		});
+
+		it('should handle both empty headers objects', () => {
+			const credentialHeaders = {};
+			const overrideHeaders = {};
+			const result = mergeHeaders(credentialHeaders, overrideHeaders);
+			expect(result).toEqual({});
+		});
+
+		it('should merge multiple headers correctly', () => {
+			const credentialHeaders = {
+				'X-Api-Key': 'cred-key',
+				'Content-Type': 'application/json',
+				Accept: 'application/json',
+			};
+			const overrideHeaders = {
+				Authorization: 'Bearer new-token',
+				'Content-Type': 'text/plain',
+			};
+			const result = mergeHeaders(credentialHeaders, overrideHeaders);
+			expect(result).toEqual({
+				'X-Api-Key': 'cred-key',
+				'Content-Type': 'text/plain',
+				Accept: 'application/json',
+				Authorization: 'Bearer new-token',
+			});
+		});
+	});
+});

--- a/nodes/McpClient/utils.ts
+++ b/nodes/McpClient/utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Parse headers from newline-separated NAME=VALUE format
+ */
+export function parseHeaders(headerString: string): Record<string, string> {
+	const headers: Record<string, string> = {};
+	if (headerString) {
+		const headerLines = headerString.split('\n');
+		for (const line of headerLines) {
+			const equalsIndex = line.indexOf('=');
+			// Ensure '=' is present and not the first character of the line
+			if (equalsIndex > 0) {
+				const name = line.substring(0, equalsIndex).trim();
+				const value = line.substring(equalsIndex + 1).trim();
+				// Add to headers object if key is not empty and value is defined
+				if (name && value !== undefined) {
+					headers[name] = value;
+				}
+			}
+		}
+	}
+	return headers;
+}
+
+/**
+ * Merge headers from credentials with dynamic headers
+ * Dynamic headers take precedence over credential headers
+ */
+export function mergeHeaders(
+	credentialHeaders: Record<string, string>,
+	dynamicHeaders: Record<string, string>,
+): Record<string, string> {
+	return { ...credentialHeaders, ...dynamicHeaders };
+}


### PR DESCRIPTION
## Description
Adds Headers Override functionality for MCP Client node, allowing dynamic header injection for HTTP and SSE connections. Override headers take precedence over credential headers, enabling per-workflow customization of API requests.

## Related Issue
N/A

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- Added 12 unit tests for `parseHeaders` and `mergeHeaders` utility functions (all passing)
- Tested locally in Docker n8n instance (v1.121.2)
- Verified header parsing with various formats (newline-separated NAME=VALUE)
- Validated header merging with precedence (override > credential)
- Confirmed UI field visibility (HTTP/SSE only)

## Checklist
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Release Notes
**New Feature: Headers Override**
- Add ability to override HTTP headers for MCP operations
- Supports all operations: executeTool, readResource, listTools, etc.
- Override headers take precedence over credential headers
- Available for HTTP Streamable and SSE connection types
- Format: newline-separated `NAME=VALUE` pairs

## Screenshots (if applicable)
<img width="458" height="589" alt="image" src="https://github.com/user-attachments/assets/b7e5d279-d725-4984-8ce2-3fac4de8f21c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Headers Override" parameter to MCP Client node for SSE and HTTP connections. Users can specify custom request headers in NAME=VALUE format; override headers take precedence over default headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->