### PR TITLE
fix(sse): use fetch override for eventSourceInit to correctly pass custom headers

### DIFF
--- a/nodes/McpClient/McpClient.node.ts
+++ b/nodes/McpClient/McpClient.node.ts
@@ -325,13 +325,29 @@ export class McpClient implements INodeType {
 				// Merge headers with override headers taking precedence
 				const headers = mergeHeaders(credentialHeaders, overrideHeaders);
 
-				// Create SSE transport with dynamic import to avoid TypeScript errors
+				// Create SSE transport.
+				// FIX (#148): The native EventSource API ignores a plain `headers` object passed
+				// via `eventSourceInit`. Custom headers (e.g. Authorization) were silently
+				// dropped, breaking any authenticated SSE endpoint.
+				//
+				// Solution: mirror the official n8n McpClientTool approach — supply a custom
+				// `fetch` function that explicitly merges user headers with the required
+				// `Accept: text/event-stream` header on every SSE request.
 				transport = new SSEClientTransport(
 					// @ts-ignore
 					new URL(sseUrl),
 					{
 						// @ts-ignore
-						eventSourceInit: { headers },
+						eventSourceInit: {
+							fetch: async (url: string | URL, init?: RequestInit) =>
+								await fetch(url, {
+									...init,
+									headers: {
+										...headers,
+										Accept: 'text/event-stream',
+									},
+								}),
+						},
 						// @ts-ignore
 						requestInit: {
 							headers,


### PR DESCRIPTION
## Problem

The SSE transport's `eventSourceInit` was configured as:

```ts
eventSourceInit: { headers },
```

The native `EventSource` API **does not support a `headers` property**. As a result, any custom headers set in credentials (e.g. `Authorization: Bearer <token>`) were **silently dropped on every SSE connection**, causing:

- `401 Unauthorized` / `403 Forbidden` errors on authenticated MCP servers (e.g. Elastic MCP — see #131)
- Headers override feature completely non-functional for SSE transport
- The `Accept: text/event-stream` header not being set explicitly, which some strict servers require

This is the root cause of the bug originally reported in #148.

## Root Cause

The `EventSource` constructor only accepts a URL and an `{ withCredentials }` option — it has no `headers` API. To send custom headers with SSE, the transport must be given a custom `fetch` function that injects the headers on the underlying HTTP request.

## Fix

Mirror the official [n8n `McpClientTool` implementation](https://github.com/n8n-io/n8n/blob/n8n%401.98.2/packages/%40n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts#L166) by replacing the broken `eventSourceInit: { headers }` with a `fetch` override:

```ts
// BEFORE (broken)
eventSourceInit: { headers },

// AFTER (fixed)
eventSourceInit: {
  fetch: async (url, init) =>
    await fetch(url, {
      ...init,
      headers: {
        ...headers,
        Accept: 'text/event-stream',
      },
    }),
},
```

This ensures:
1. All user-supplied headers (auth tokens, API keys, etc.) are sent on every SSE request
2. The `Accept: text/event-stream` header is always included for proper SSE negotiation
3. Behaviour is consistent with the official n8n MCP node

## Testing

- Authenticated SSE servers (Bearer token, API key header) should now connect successfully
- Unauthenticated SSE servers are unaffected (empty headers object is a no-op)
- The `headersOverride` node parameter now works correctly for SSE connections

## Related Issues

- Fixes #148 
- Related to #131 (Elastic MCP `MCP error -32000` caused by missing auth headers)
- Related to #184 (custom authentication request)

---

> Identified by reviewing the source against the MCP SDK and the official n8n implementation. The fix is a minimal, targeted change with zero functional impact on non-SSE transports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSE connections so authentication and custom headers are consistently preserved.
  * Improved compatibility with services requiring the `Accept: text/event-stream` header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->